### PR TITLE
Lowercase HighlightMode attribute

### DIFF
--- a/lambda/py/lambda_function.py
+++ b/lambda/py/lambda_function.py
@@ -151,7 +151,7 @@ class KaraokeIntentHandler(AbstractRequestHandler):
                 commands=[
                     SpeakItemCommand(
                         component_id="karaokespeechtext",
-                        highlight_mode=HighlightMode.LINE)
+                        highlight_mode=HighlightMode.line)
                 ]
             )
         )


### PR DESCRIPTION
*Description of changes:*
Bugfix: Karaoke example references the HighlightMode using all capitals. `LINE` 
Should be `HighlightMode.line`. [See interface documentation](https://alexa-skills-kit-python-sdk.readthedocs.io/en/latest/models/ask_sdk_model.interfaces.alexa.presentation.apl.html#module-ask_sdk_model.interfaces.alexa.presentation.apl.highlight_mode).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
